### PR TITLE
Add note about collection element order

### DIFF
--- a/docs/src/main/asciidoc/config-mappings.adoc
+++ b/docs/src/main/asciidoc/config-mappings.adoc
@@ -388,6 +388,8 @@ The `List` or `Set` mappings can use xref:config-reference.adoc#indexed-properti
 configuration values in mapping groups. For collection with simple element types like `String`, their configuration
 value is a comma separated string.
 
+NOTE: Note that only the `List` mapping is able to main element order. Hence, with `Set` mappings the element order is not maintained from the configuration files but is random.
+
 ==== Maps ====
 
 A config mapping is also able to map a `Map`:


### PR DESCRIPTION
Through a discussion at https://quarkusio.zulipchat.com/#narrow/stream/187030-users/topic/YAML.20config.20mapping.20collections.3A.20Set.20!.3D.20List.20wrt.20value.20order with @radcortez we confirmed that only `List` mappings maintain order.